### PR TITLE
Use range input instead of select for the text speed

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,9 +6,12 @@ export enum ViewRatio {
   sixteenByNine = "16/9",
 }
 
-export enum TEXT_SPEED {
-  instant = 0,
-  fast = 1,
-  normal = 20,
-  slow = 50,
+export const TEXT_SPEED_MAX = 3000
+export const TEXT_SPEED_STEP_WIDTH = TEXT_SPEED_MAX / 30 // to always have 30 steps like the other settings
+
+export function TextSettingsToCharacterDelay(xi: number) {
+  xi = 1 - xi / TEXT_SPEED_MAX; // normalize input between 1 and 0
+  const slowest = 50;
+  const zoom = 0.18; // zoom on the exponent function (steepness of the curve)
+  return (((slowest * zoom + 1) ** xi) - 1) / zoom
 }


### PR DESCRIPTION
Hello,

I've replace the text speed enum to be a range input like in most modern Visual Novel.

I've used a logarithm function to map the values here is what the function looks like.

![image](https://github.com/user-attachments/assets/4893cea2-acef-4187-ab62-3c211bfa79ad)

You can change the `z` value to adjust the steepness of the curve. Large value mean steeper start. I've tried to match the first thrid to be the enum normal speed.

https://github.com/requinDr/tsukiweb-public/pull/19

Best
Raphaël