### PR TITLE
Remove unnecessary music restart at scene change

### DIFF
--- a/src/utils/AudioManager.ts
+++ b/src/utils/AudioManager.ts
@@ -99,7 +99,7 @@ export class AudioChannel {
      * @param forceRestart `true` if the sound must be restarted if it is
      *          already playing, `false` otherwise. Defaults to `true`
      */
-    async play(id: string, {loop = false, forceRestart = true} = {}) {
+    async play(id: string, {loop = false, forceRestart = false} = {}) {
  
         const context = this.context
         this._sourceId = id


### PR DESCRIPTION
Correct the issue that when finishing a scene with track A and and the next scene have the scene track the music will restart by setting false as the default for forceRestart (track8 still restarted as intended if you load a save at this point from title screen)
https://github.com/requinDr/tsukiweb-public/issues/56